### PR TITLE
Fix GCC 11 compilation errors

### DIFF
--- a/src/model/STRAND.h
+++ b/src/model/STRAND.h
@@ -23,6 +23,7 @@
 #ifndef ANNOTATIONLIFTOVER_STRAND_H
 #define ANNOTATIONLIFTOVER_STRAND_H
 #include "map"
+#include <ostream>
 enum STRAND {
     POSITIVE=0, NEGATIVE
 };

--- a/src/model/Transcript.h
+++ b/src/model/Transcript.h
@@ -33,6 +33,7 @@
 #include <set>
 #include <map>
 #include <algorithm>
+#include <limits>
 
 class Transcript{
     private:


### PR DESCRIPTION
This fixes compilation under GCC 11, though it would be good to test GCC 7-9 to make sure nothing broke